### PR TITLE
Change front page link for BTC Bond deck

### DIFF
--- a/src/pug/index.pug
+++ b/src/pug/index.pug
@@ -19,7 +19,7 @@ block content
 		h1(style="margin-top: 0px;") The Bitcoin Bond Initiative
 		p Flux is excited to move forward with our BTC Bond initiative, a way to securitize Bitcoin into a deliverable corporate bond that can be held in financial accounts.
 
-		a.button.is-link(href='https://docs.google.com/presentation/d/16P5bMeqFsXGvXFl0IWR7m2F3fUkgSYR1PAU8Re9JP4k/present?token=AC4w5VjDVuOIgqGv7gYYTKrycYgIsAWeog%3A1588794108983&includes_info_params=1&eisi=CIOq86P_n-kCFe6JIwAdErQGbQ#slide=id.g75218c2399_41_0')
+		a.button.is-link(href='https://deck.fluxfinancial.net/#/')
 			span.icon
 				i.iconify(data-icon='ic:baseline-insert-drive-file')
 			span View the deck


### PR DESCRIPTION
Do this instead to change the link on the front page from Google docs to the Reveal.js deck located at deck.fluxfinancial.net